### PR TITLE
chore: release v0.1.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "objstore",
  "objstore_fs",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "objstore"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "objstore_config"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "objstore_fs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "objstore_logfs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "objstore_memory"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "objstore_s3_light"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "objstore_test"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,17 +29,17 @@ keywords = [
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/theduke/objstore"
 edition = "2024"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 
 [workspace.dependencies]
 
 # Repo-local crates
-objstore = { path = "./objstore", version = "0.1.0-alpha.1" }
-objstore_config = { path = "./objstore_config", version = "0.1.0-alpha.1" }
-objstore_fs = { path = "./objstore_fs", version = "0.1.0-alpha.1" }
+objstore = { path = "./objstore", version = "0.1.0-alpha.2" }
+objstore_config = { path = "./objstore_config", version = "0.1.0-alpha.2" }
+objstore_fs = { path = "./objstore_fs", version = "0.1.0-alpha.2" }
 objstore_logfs = { path = "./objstore_logfs", version = "0.1.0-alpha.1" }
-objstore_memory = { path = "./objstore_memory", version = "0.1.0-alpha.1" }
-objstore_s3_light = { path = "./objstore_s3_light", version = "0.1.0-alpha.1" }
+objstore_memory = { path = "./objstore_memory", version = "0.1.0-alpha.2" }
+objstore_s3_light = { path = "./objstore_s3_light", version = "0.1.0-alpha.2" }
 objstore_test = { path = "./objstore_test", version = "0.1.0-alpha.1" }
 
 # External crates

--- a/objstore/CHANGELOG.md
+++ b/objstore/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore-v0.1.0-alpha.1...objstore-v0.1.0-alpha.2) - 2026-06-29
+
+### Added
+
+- Add a PrefixObjStore
+- Add ObjStore::as_any
+- Add ObjStore::generate_upload_url
+- Add S3ObjStore::bucket_create()
+- *(s3-light)* Parse md5 and sha256 hashes for object metadata
+- Allow specifying the mime_type for objects
+- Add mime_type to ObjectMeta
+- Add objstore_config crate
+- Implement ListArgs::delimiter support
+- Add ObjStore::generate_download_url()
+
+### Fixed
+
+- refine typed object store errors
+- *(objstore)* correct if-none-match conditions
+- Make size semi-mandatory for stream uploads
+- fixup! feat: Add ObjStore::generate_download_url()
+
+### Other
+
+- Fix clippy large error lint
+- Fix prefix stream errors and remove debug logs
+- Use well-known typed ObjStoreError instead of anyhow
+- add description to all crates
+- add description to all crates
+- Inherit crate version from workspace + harmonize deps
+- Fix some clippy lints
+- Fix docs build issues
+- cargo fmt
+- Rename KeyMeta* to ObjectMeta*
+- Add objstore_gcs to README
+- Delete old unused backend directory
+- Fix doctests
+- Give birth to the objstore

--- a/objstore_config/CHANGELOG.md
+++ b/objstore_config/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/objstore_fs/CHANGELOG.md
+++ b/objstore_fs/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore_fs-v0.1.0-alpha.1...objstore_fs-v0.1.0-alpha.2) - 2026-06-29
+
+### Added
+
+- Add ObjStore::generate_upload_url
+
+### Fixed
+
+- refine typed object store errors
+- Make size semi-mandatory for stream uploads
+
+### Other
+
+- Use well-known typed ObjStoreError instead of anyhow

--- a/objstore_memory/CHANGELOG.md
+++ b/objstore_memory/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore_memory-v0.1.0-alpha.1...objstore_memory-v0.1.0-alpha.2) - 2026-06-29
+
+### Added
+
+- Add ObjStore::generate_upload_url
+- Add objstore_config crate
+- Implement ListArgs::delimiter support
+- Add ObjStore::generate_download_url()
+
+### Fixed
+
+- Make size semi-mandatory for stream uploads
+
+### Other
+
+- Use well-known typed ObjStoreError instead of anyhow
+- Unify Rust edition usage across crates
+- add description to all crates
+- Inherit crate version from workspace + harmonize deps
+- cargo fmt
+- Rename KeyMeta* to ObjectMeta*
+- Add objstore_gcs to README
+- Give birth to the objstore

--- a/objstore_s3_light/CHANGELOG.md
+++ b/objstore_s3_light/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore_s3_light-v0.1.0-alpha.1...objstore_s3_light-v0.1.0-alpha.2) - 2026-06-29
+
+### Added
+
+- Add ObjStore::generate_upload_url
+
+### Fixed
+
+- refine typed object store errors
+- *(s3-light)* improve S3 compatibility
+- Make size semi-mandatory for stream uploads
+
+### Other
+
+- Fix clippy large error lint
+- Use well-known typed ObjStoreError instead of anyhow
+- Add fetch_metadata_after_put setting
+- Upgrade rusty-s3 to 0.9
+- Upgrade reqwest to 0.13


### PR DESCRIPTION



## 🤖 New release

* `objstore`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)
* `objstore_memory`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)
* `objstore_fs`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)
* `objstore_s3_light`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)
* `objstore_config`: 0.1.0-alpha.1 -> 0.1.0-alpha.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `objstore`

<blockquote>

## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore-v0.1.0-alpha.1...objstore-v0.1.0-alpha.2) - 2026-06-29

### Added

- Add a PrefixObjStore
- Add ObjStore::as_any
- Add ObjStore::generate_upload_url
- Add S3ObjStore::bucket_create()
- *(s3-light)* Parse md5 and sha256 hashes for object metadata
- Allow specifying the mime_type for objects
- Add mime_type to ObjectMeta
- Add objstore_config crate
- Implement ListArgs::delimiter support
- Add ObjStore::generate_download_url()

### Fixed

- refine typed object store errors
- *(objstore)* correct if-none-match conditions
- Make size semi-mandatory for stream uploads
- fixup! feat: Add ObjStore::generate_download_url()

### Other

- Fix clippy large error lint
- Fix prefix stream errors and remove debug logs
- Use well-known typed ObjStoreError instead of anyhow
- add description to all crates
- add description to all crates
- Inherit crate version from workspace + harmonize deps
- Fix some clippy lints
- Fix docs build issues
- cargo fmt
- Rename KeyMeta* to ObjectMeta*
- Add objstore_gcs to README
- Delete old unused backend directory
- Fix doctests
- Give birth to the objstore
</blockquote>

## `objstore_memory`

<blockquote>

## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore_memory-v0.1.0-alpha.1...objstore_memory-v0.1.0-alpha.2) - 2026-06-29

### Added

- Add ObjStore::generate_upload_url
- Add objstore_config crate
- Implement ListArgs::delimiter support
- Add ObjStore::generate_download_url()

### Fixed

- Make size semi-mandatory for stream uploads

### Other

- Use well-known typed ObjStoreError instead of anyhow
- Unify Rust edition usage across crates
- add description to all crates
- Inherit crate version from workspace + harmonize deps
- cargo fmt
- Rename KeyMeta* to ObjectMeta*
- Add objstore_gcs to README
- Give birth to the objstore
</blockquote>

## `objstore_fs`

<blockquote>

## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore_fs-v0.1.0-alpha.1...objstore_fs-v0.1.0-alpha.2) - 2026-06-29

### Added

- Add ObjStore::generate_upload_url

### Fixed

- refine typed object store errors
- Make size semi-mandatory for stream uploads

### Other

- Use well-known typed ObjStoreError instead of anyhow
</blockquote>

## `objstore_s3_light`

<blockquote>

## [0.1.0-alpha.2](https://github.com/theduke/objstore/compare/objstore_s3_light-v0.1.0-alpha.1...objstore_s3_light-v0.1.0-alpha.2) - 2026-06-29

### Added

- Add ObjStore::generate_upload_url

### Fixed

- refine typed object store errors
- *(s3-light)* improve S3 compatibility
- Make size semi-mandatory for stream uploads

### Other

- Fix clippy large error lint
- Use well-known typed ObjStoreError instead of anyhow
- Add fetch_metadata_after_put setting
- Upgrade rusty-s3 to 0.9
- Upgrade reqwest to 0.13
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).